### PR TITLE
Add inline button support

### DIFF
--- a/backend/routers/constructor.py
+++ b/backend/routers/constructor.py
@@ -76,6 +76,7 @@ async def send_message(request: SendTextMessageRequest):
             text,
             inline_buttons=inline_buttons,
             reply_keyboard=reply_keyboard,
+            remove_keyboard=not inline_buttons and not quick_replies,
             bot_id=request.chat.messengerId,
         )
 
@@ -136,6 +137,7 @@ async def send_media_message(request: SendMediaMessageRequest):
             caption,
             inline_buttons=inline_buttons,
             reply_keyboard=reply_keyboard,
+            remove_keyboard=not inline_buttons and not quick_replies,
             bot_id=request.chat.messengerId,
         )
 

--- a/backend/routers/constructor.py
+++ b/backend/routers/constructor.py
@@ -49,11 +49,13 @@ async def send_message(request: SendTextMessageRequest):
         token = db.get_bot_token(request.chat.messengerId)
         chat_id = request.chat.contact
         text = request.text
+        inline_buttons = request.inlineButtons
 
         response = await sender_adapter.send_message(
             token,
             chat_id,
             text,
+            inline_buttons=inline_buttons,
             bot_id=request.chat.messengerId,
         )
 
@@ -84,6 +86,7 @@ async def send_media_message(request: SendMediaMessageRequest):
         file_url = request.file.url
         file_mime = request.file.mime
         caption = request.caption
+        inline_buttons = request.inlineButtons
 
         response = await sender_adapter.send_media(
             token,
@@ -92,6 +95,7 @@ async def send_media_message(request: SendMediaMessageRequest):
             file_url,
             file_mime,
             caption,
+            inline_buttons=inline_buttons,
             bot_id=request.chat.messengerId,
         )
 

--- a/backend/routers/constructor.py
+++ b/backend/routers/constructor.py
@@ -26,7 +26,7 @@ async def list_messengers():
             }
             for bot_id, user_id, name, surname in bot_users
         ]
-        print(items)
+
         return {"items": items}
     except Exception as e:
         return JSONResponse(
@@ -46,15 +46,11 @@ async def get_status(id: int):
 @router.post('/sendTextMessage', description="Sends message to a chat")
 async def send_message(request: SendTextMessageRequest):
     try:
-        print("sendTextMessage request:", request.dict())
         token = db.get_bot_token(request.chat.messengerId)
         chat_id = request.chat.contact
         text = request.text
         inline_buttons = request.inlineButtons
         quick_replies = request.quickReplies
-
-        if inline_buttons or quick_replies:
-            print("INLINE BUTTONS RECEIVED")
 
         reply_keyboard = None
         if quick_replies:
@@ -101,7 +97,6 @@ async def send_message(request: SendTextMessageRequest):
 @router.post('/sendMediaMessage', description="Sends media message to a chat")
 async def send_media_message(request: SendMediaMessageRequest):
     try:
-        print("sendMediaMessage request:", request.dict())
         token = db.get_bot_token(request.chat.messengerId)
         chat_id = request.chat.contact
         file_type = request.file.type
@@ -110,9 +105,6 @@ async def send_media_message(request: SendMediaMessageRequest):
         caption = request.caption
         inline_buttons = request.inlineButtons
         quick_replies = request.quickReplies
-
-        if inline_buttons or quick_replies:
-            print("INLINE BUTTONS RECEIVED")
 
         reply_keyboard = None
         if quick_replies:

--- a/backend/routers/constructor.py
+++ b/backend/routers/constructor.py
@@ -46,10 +46,14 @@ async def get_status(id: int):
 @router.post('/sendTextMessage', description="Sends message to a chat")
 async def send_message(request: SendTextMessageRequest):
     try:
+        print("sendTextMessage request:", request.dict())
         token = db.get_bot_token(request.chat.messengerId)
         chat_id = request.chat.contact
         text = request.text
         inline_buttons = request.inlineButtons
+
+        if inline_buttons:
+            print("INLINE BUTTONS RECEIVED")
 
         response = await sender_adapter.send_message(
             token,
@@ -80,6 +84,7 @@ async def send_message(request: SendTextMessageRequest):
 @router.post('/sendMediaMessage', description="Sends media message to a chat")
 async def send_media_message(request: SendMediaMessageRequest):
     try:
+        print("sendMediaMessage request:", request.dict())
         token = db.get_bot_token(request.chat.messengerId)
         chat_id = request.chat.contact
         file_type = request.file.type
@@ -87,6 +92,9 @@ async def send_media_message(request: SendMediaMessageRequest):
         file_mime = request.file.mime
         caption = request.caption
         inline_buttons = request.inlineButtons
+
+        if inline_buttons:
+            print("INLINE BUTTONS RECEIVED")
 
         response = await sender_adapter.send_media(
             token,

--- a/backend/routers/constructor.py
+++ b/backend/routers/constructor.py
@@ -51,15 +51,31 @@ async def send_message(request: SendTextMessageRequest):
         chat_id = request.chat.contact
         text = request.text
         inline_buttons = request.inlineButtons
+        quick_replies = request.quickReplies
 
-        if inline_buttons:
+        if inline_buttons or quick_replies:
             print("INLINE BUTTONS RECEIVED")
+
+        reply_keyboard = None
+        if quick_replies:
+            reply_keyboard = [
+                [
+                    {
+                        **{"text": qr.text},
+                        **({"request_contact": True} if qr.type.lower() == "phone" else {}),
+                        **({"request_location": True} if qr.type.lower() in {"geolocation", "location"} else {}),
+                    }
+                    for qr in row
+                ]
+                for row in quick_replies
+            ]
 
         response = await sender_adapter.send_message(
             token,
             chat_id,
             text,
             inline_buttons=inline_buttons,
+            reply_keyboard=reply_keyboard,
             bot_id=request.chat.messengerId,
         )
 
@@ -92,9 +108,24 @@ async def send_media_message(request: SendMediaMessageRequest):
         file_mime = request.file.mime
         caption = request.caption
         inline_buttons = request.inlineButtons
+        quick_replies = request.quickReplies
 
-        if inline_buttons:
+        if inline_buttons or quick_replies:
             print("INLINE BUTTONS RECEIVED")
+
+        reply_keyboard = None
+        if quick_replies:
+            reply_keyboard = [
+                [
+                    {
+                        **{"text": qr.text},
+                        **({"request_contact": True} if qr.type.lower() == "phone" else {}),
+                        **({"request_location": True} if qr.type.lower() in {"geolocation", "location"} else {}),
+                    }
+                    for qr in row
+                ]
+                for row in quick_replies
+            ]
 
         response = await sender_adapter.send_media(
             token,
@@ -104,6 +135,7 @@ async def send_media_message(request: SendMediaMessageRequest):
             file_mime,
             caption,
             inline_buttons=inline_buttons,
+            reply_keyboard=reply_keyboard,
             bot_id=request.chat.messengerId,
         )
 

--- a/backend/routers/telegram.py
+++ b/backend/routers/telegram.py
@@ -49,7 +49,6 @@ def tr(key: str, locale: str) -> str:
 async def handle_webhook(bot_id: int, request: Request):
     try:
         update = await request.json()
-        print("Webhook update:", update)
 
         token = db.get_bot_token(bot_id)
         if not token:
@@ -60,11 +59,9 @@ async def handle_webhook(bot_id: int, request: Request):
         message = update.get("message") or update.get("edited_message")
         callback = update.get("callback_query")
         if not message and not callback:
-            print("Exception: Unsupported update type")
             raise HTTPException(status_code=400, detail="Unsupported update type")
 
         if callback:
-            print("Callback query:", callback)
             contact_id = callback["from"]["id"]
             text = callback.get("data", "")
             message = callback.get("message", {})
@@ -255,7 +252,6 @@ async def handle_webhook(bot_id: int, request: Request):
             response = await client.post(f"{INTEGRATION_URL}/{INTEGRATION_CODE}/12/event", json=request_body, headers=headers) #TODO replace with bot_id
 
         if response.status_code >= 400:
-            print("Exception", response.text)
             raise HTTPException(status_code=response.status_code, detail=response.text)
 
         if response.content:
@@ -267,5 +263,4 @@ async def handle_webhook(bot_id: int, request: Request):
             return {"status": "ok", "message": "No content"}
     
     except Exception as e:
-        print("Exception", e)
         return JSONResponse(content={"ok": False, "error": str(e)}, status_code=400)

--- a/backend/routers/telegram.py
+++ b/backend/routers/telegram.py
@@ -49,6 +49,7 @@ def tr(key: str, locale: str) -> str:
 async def handle_webhook(bot_id: int, request: Request):
     try:
         update = await request.json()
+        print("Webhook update:", update)
 
         token = db.get_bot_token(bot_id)
         if not token:
@@ -63,6 +64,7 @@ async def handle_webhook(bot_id: int, request: Request):
             raise HTTPException(status_code=400, detail="Unsupported update type")
 
         if callback:
+            print("Callback query:", callback)
             contact_id = callback["from"]["id"]
             text = callback.get("data", "")
             message = callback.get("message", {})

--- a/backend/services/sender_adapter.py
+++ b/backend/services/sender_adapter.py
@@ -1,4 +1,5 @@
 import httpx
+import json
 from io import BytesIO
 from services.helper_functions import guess_filename
 from typing import List, Optional, Dict, Any
@@ -67,6 +68,7 @@ async def send_media(
     file_url: str,
     file_mime: str,
     caption: str,
+    inline_buttons: Optional[List[List[Dict[str, Any]]]] = None,
     bot_id: Optional[int] = None,
 ):
     if bot_id is not None:
@@ -113,6 +115,8 @@ async def send_media(
         }
         if caption and file_type in ["image", "video", "document"]:
             data["caption"] = caption[:1024]
+        if inline_buttons:
+            data["reply_markup"] = json.dumps({"inline_keyboard": inline_buttons})
 
         response = await client.post(
             f"https://api.telegram.org/bot{token}/{method}",

--- a/backend/services/sender_adapter.py
+++ b/backend/services/sender_adapter.py
@@ -70,6 +70,7 @@ async def send_media(
     caption: str,
     inline_buttons: Optional[List[List[Dict[str, Any]]]] = None,
     reply_keyboard: Optional[List[List[Dict[str, Any]]]] = None,
+    remove_keyboard: bool = False,
     bot_id: Optional[int] = None,
 ):
     if bot_id is not None:
@@ -124,6 +125,8 @@ async def send_media(
                 "resize_keyboard": True,
                 "one_time_keyboard": True,
             })
+        elif remove_keyboard:
+            data["reply_markup"] = json.dumps({"remove_keyboard": True})
 
         response = await client.post(
             f"https://api.telegram.org/bot{token}/{method}",

--- a/backend/services/sender_adapter.py
+++ b/backend/services/sender_adapter.py
@@ -69,6 +69,7 @@ async def send_media(
     file_mime: str,
     caption: str,
     inline_buttons: Optional[List[List[Dict[str, Any]]]] = None,
+    reply_keyboard: Optional[List[List[Dict[str, Any]]]] = None,
     bot_id: Optional[int] = None,
 ):
     if bot_id is not None:
@@ -117,6 +118,12 @@ async def send_media(
             data["caption"] = caption[:1024]
         if inline_buttons:
             data["reply_markup"] = json.dumps({"inline_keyboard": inline_buttons})
+        elif reply_keyboard:
+            data["reply_markup"] = json.dumps({
+                "keyboard": reply_keyboard,
+                "resize_keyboard": True,
+                "one_time_keyboard": True,
+            })
 
         response = await client.post(
             f"https://api.telegram.org/bot{token}/{method}",


### PR DESCRIPTION
## Summary
- forward inline buttons for text messages and media messages
- add inline button support to the Telegram sender
- handle `callback_query` events in the webhook

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68547e9f47f0832b87429a46ed74593d