### PR TITLE
Add centralized logging with Loki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Telegram Corporate AI Integration
 
-This repository contains a full-stack application for integrating **Telegram bots** with a corporate messaging service. It consists of a **FastAPI** backend and a **React** frontend. Infrastructure services such as PostgreSQL, Redis, Prometheus, and Grafana are orchestrated via **Docker Compose**.
+This repository contains a full-stack application for integrating **Telegram bots** with a corporate messaging service. It consists of a **FastAPI** backend and a **React** frontend. Infrastructure services such as PostgreSQL, Redis, Prometheus, Loki, and Grafana are orchestrated via **Docker Compose**.
 
 ---
 
@@ -36,6 +36,7 @@ telegram-corporate-ai/
 - **redis** – Redis for caching
 - **prometheus** – Metric collection service
 - **grafana** – Visualization dashboard
+- **loki** – Log aggregation service
 
 ---
 
@@ -61,6 +62,7 @@ docker-compose up --build
    - Swagger Docs: [http://localhost:8000/docs](http://localhost:8000/docs)
    - Prometheus: [http://localhost:9090](http://localhost:9090)
    - Grafana: [http://localhost:3001](http://localhost:3001)
+   - Loki: [http://localhost:3100](http://localhost:3100)
 
 ---
 
@@ -82,6 +84,7 @@ docker-compose up --build
 | `REDIS_PASSWORD` | Redis password |
 | `REDIS_CACHE_TIME` | TTL for Redis cache (in seconds) |
 | `PROMETHEUS_JOBS_PATH` | Path to Prometheus jobs config file |
+| `LOKI_URL` | URL for Loki log ingestion |
 
 ---
 
@@ -114,6 +117,7 @@ Located in the `backend/` directory. The main features:
 - Redis models: `backend/constants/redis_models.py`
 - Prometheus metrics: `backend/constants/prometheus_models.py`
 - Logs: `logs/interactions.log`
+- Logs forwarded to Loki
 
 ---
 

--- a/backend/config/grafana_dashboard.json
+++ b/backend/config/grafana_dashboard.json
@@ -45,21 +45,11 @@
       "type": "logs",
       "title": "Interaction Logs",
       "gridPos": {"x": 12, "y": 8, "w": 12, "h": 8},
-      "datasource": "Prometheus",
+      "datasource": "Loki",
       "targets": [
         {
-          "expr": "increase(bot_message_text_total[1m])",
-          "legendFormat": "{{direction}}",
-          "format": "table",
-          "instant": true
-        }
-      ],
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "labels"
-          }
+          "expr": "{app=\"telegram-corp-ai\"}",
+          "refId": "A"
         }
       ]
     },

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -34,3 +34,4 @@ typing_extensions==4.13.2
 urllib3==2.4.0
 uvicorn==0.34.2
 yarl==1.20.0
+python-logging-loki==0.3.1

--- a/backend/routers/telegram.py
+++ b/backend/routers/telegram.py
@@ -53,6 +53,7 @@ def tr(key: str, locale: str) -> str:
 async def handle_webhook(bot_id: int, request: Request):
     """Process Telegram webhook updates and forward messages."""
     try:
+        interaction_logger.info(f"Webhook call for bot_id={bot_id}")
         update = await request.json()
 
         token = db.get_bot_token(bot_id)
@@ -267,4 +268,5 @@ async def handle_webhook(bot_id: int, request: Request):
             return {"status": "ok", "message": "No content"}
     
     except Exception as e:
+        interaction_logger.error(f"Webhook handling failed for bot_id={bot_id}: {e}")
         return JSONResponse(content={"ok": False, "error": str(e)}, status_code=400)

--- a/backend/services/logging_setup.py
+++ b/backend/services/logging_setup.py
@@ -1,16 +1,31 @@
 import logging
 import os
 
+from logging_loki import LokiHandler
+
 LOG_DIR = os.getenv("LOG_DIR", "logs")
 os.makedirs(LOG_DIR, exist_ok=True)
+
+
+handlers = [
+    logging.FileHandler(os.path.join(LOG_DIR, "interactions.log")),
+    logging.StreamHandler(),
+]
+
+loki_url = os.getenv("LOKI_URL")
+if loki_url:
+    handlers.append(
+        LokiHandler(
+            url=f"{loki_url.rstrip('/')}/loki/api/v1/push",
+            tags={"app": "telegram-corp-ai"},
+            version="1",
+        )
+    )
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
-    handlers=[
-        logging.FileHandler(os.path.join(LOG_DIR, "interactions.log")),
-        logging.StreamHandler()
-    ]
+    handlers=handlers,
 )
 
 interaction_logger = logging.getLogger("interaction")

--- a/backend/services/webhook_server.py
+++ b/backend/services/webhook_server.py
@@ -1,5 +1,6 @@
 import httpx
 from typing import Any, Dict
+from services.logging_setup import interaction_logger
 
 async def get_bot_id(token: str) -> int:
     async with httpx.AsyncClient() as client:
@@ -7,9 +8,12 @@ async def get_bot_id(token: str) -> int:
         data = resp.json()
 
         if data['ok'] == False:
+            interaction_logger.error("Failed to fetch bot id")
             return None
-        
-        return data["result"]["id"]
+
+        bot_id = data["result"]["id"]
+        interaction_logger.info(f"Fetched bot id {bot_id}")
+        return bot_id
 
 async def get_bot_name(token: str) -> str:
     async with httpx.AsyncClient() as client:
@@ -17,9 +21,12 @@ async def get_bot_name(token: str) -> str:
         data = resp.json()
 
         if data['ok'] == False:
+            interaction_logger.error("Failed to fetch bot name")
             return None
 
-        return data["result"]["username"]
+        name = data["result"]["username"]
+        interaction_logger.info(f"Fetched bot name {name}")
+        return name
 
 
 async def set_webhook(TOKEN: str, WEBHOOK_URL: str) -> Dict[str, Any]:
@@ -27,6 +34,10 @@ async def set_webhook(TOKEN: str, WEBHOOK_URL: str) -> Dict[str, Any]:
         response = await client.post(
             f'https://api.telegram.org/bot{TOKEN}/setWebhook',
             data={"url": WEBHOOK_URL}
+        )
+
+        interaction_logger.info(
+            f"Set webhook for bot token ending {TOKEN[-4:]} status={response.status_code}"
         )
 
         return {
@@ -39,6 +50,10 @@ async def delete_webhook(token: str) -> Dict[str, Any]:
     url = f"https://api.telegram.org/bot{token}/deleteWebhook"
     async with httpx.AsyncClient() as client:
         response = await client.post(url)
+
+        interaction_logger.info(
+            f"Delete webhook status={response.status_code}"
+        )
         
         return {
             "status_code": response.status_code,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,11 @@ services:
       REDIS_PASSWORD: ${REDIS_PASSWORD}
       REDIS_CACHE_TIME: ${REDIS_CACHE_TIME}
       PROMETHEUS_JOBS_PATH: /app/shared/jobs.json
+      LOKI_URL: http://loki:3100
     depends_on:
       - postgres
       - redis
+      - loki
     ports:
       - "8000:8000"
 
@@ -58,6 +60,12 @@ services:
     ports:
       - "6379:6379"
 
+  loki:
+    image: grafana/loki:2.9.7
+    command: -config.file=/etc/loki/local-config.yaml
+    ports:
+      - "3100:3100"
+
   prometheus:
     image: prom/prometheus:latest
     volumes:
@@ -79,6 +87,7 @@ services:
       - "3001:3000"
     depends_on:
       - prometheus
+      - loki
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary
- integrate python-logging-loki and configure Loki handler
- log actions across API and constructor routers
- log webhook activity and Telegram API helpers
- add Loki service in docker-compose
- update Grafana dashboard for Loki logs
- document new Loki settings in README

## Testing
- `python -m py_compile backend/app.py backend/services/logging_setup.py backend/routers/*.py backend/services/webhook_server.py`

------
https://chatgpt.com/codex/tasks/task_e_685bdbc2fe04832b8a94504e4e3debc8