### PR TITLE
Add backend tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import sqlalchemy
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+BACKEND_DIR = os.path.join(ROOT, 'backend')
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+if BACKEND_DIR not in sys.path:
+    sys.path.insert(0, BACKEND_DIR)
+
+os.environ.setdefault('FERNET_KEY', 'QFPVedhtX4KhsMWj5ONkL8pjJi0FserBtEDwGDIIDS8=')
+os.environ.setdefault('POSTGRES_URL', 'localhost')
+os.environ.setdefault('POSTGRES_USER', 'user')
+os.environ.setdefault('POSTGRES_PASSWORD', 'pass')
+os.environ.setdefault('POSTGRES_DB', 'db')
+os.environ.setdefault('REDIS_URL', 'localhost')
+os.environ.setdefault('REDIS_PASSWORD', 'pass')
+os.environ.setdefault('PROMETHEUS_JOBS_PATH', '/tmp/jobs.json')
+
+_real_create_engine = sqlalchemy.create_engine
+
+def _sqlite_engine(*args, **kwargs):
+    return _real_create_engine('sqlite:///:memory:')
+
+sqlalchemy.create_engine = _sqlite_engine

--- a/backend/tests/test_api_router.py
+++ b/backend/tests/test_api_router.py
@@ -1,0 +1,24 @@
+import types
+import pytest
+from backend.routers import api
+
+
+@pytest.mark.asyncio
+async def test_bots_by_owner(monkeypatch):
+    monkeypatch.setattr(api.db, "get_bots_by_owner_uuid", lambda owner_uuid: [(1, "Bot", "pass", "url")])
+    result = await api.bots_by_owner("owner")
+    assert result[0]["botName"] == "Bot"
+
+
+@pytest.mark.asyncio
+async def test_is_bot_verified(monkeypatch):
+    monkeypatch.setattr(api.db, "is_bot_verified", lambda bot_id: True)
+    assert await api.is_bot_verified(1) is True
+
+
+@pytest.mark.asyncio
+async def test_generate_invite(monkeypatch):
+    monkeypatch.setattr(api.db, "bot_exists", lambda bot_id: True)
+    monkeypatch.setattr(api.db, "create_pass_token", lambda bot_id: "uuid")
+    result = await api.generate_invite(1)
+    assert result == {"passUuid": "uuid"}

--- a/backend/tests/test_constructor_router.py
+++ b/backend/tests/test_constructor_router.py
@@ -1,0 +1,29 @@
+import types
+import pytest
+from backend.routers import constructor
+from backend.constants.request_models import SendTextMessageRequest, Chat
+
+
+@pytest.mark.asyncio
+async def test_get_schema(monkeypatch):
+    monkeypatch.setattr(constructor, "SCHEME", {"a": 1})
+    resp = await constructor.get_schema()
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_list_messengers(monkeypatch):
+    monkeypatch.setattr(constructor.db, "get_all_bot_users", lambda: [(1, 2, "n", "s")])
+    result = await constructor.list_messengers()
+    assert result["items"][0]["externalType"] == "employees"
+
+
+@pytest.mark.asyncio
+async def test_send_message(monkeypatch):
+    req = SendTextMessageRequest(chat=Chat(externalId="1", messengerInstance="1", contact="1", messengerId="1"), text="hi")
+    monkeypatch.setattr(constructor.db, "get_bot_token", lambda bot_id: "token")
+    async def fake_send(*args, **kwargs):
+        return {"status_code": 200, "body": {}}
+    monkeypatch.setattr(constructor.sender_adapter, "send_message", fake_send)
+    result = await constructor.send_message(req)
+    assert result["externalId"] == "1"

--- a/backend/tests/test_helper_functions.py
+++ b/backend/tests/test_helper_functions.py
@@ -1,0 +1,20 @@
+import re
+from backend.services.helper_functions import guess_filename, generate_uuid
+
+
+def test_guess_filename_content_disposition():
+    headers = {"Content-Disposition": 'attachment; filename="test.txt"'}
+    assert guess_filename("http://example.com/file", headers) == "test.txt"
+
+
+def test_guess_filename_from_url():
+    assert guess_filename("http://example.com/path/img.jpg", {}) == "img.jpg"
+
+
+def test_generate_uuid_unique():
+    uuid1 = generate_uuid()
+    uuid2 = generate_uuid()
+    pattern = re.compile(r"^[a-f0-9-]{36}$")
+    assert uuid1 != uuid2
+    assert pattern.match(uuid1)
+    assert pattern.match(uuid2)

--- a/backend/tests/test_metrics_router.py
+++ b/backend/tests/test_metrics_router.py
@@ -1,0 +1,35 @@
+import json
+import pytest
+from backend.routers import metrics
+from constants.request_models import Job
+
+
+@pytest.mark.asyncio
+async def test_metrics_returns_response():
+    resp = await metrics.metrics()
+    assert resp.media_type == metrics.CONTENT_TYPE_LATEST
+
+
+@pytest.mark.asyncio
+async def test_get_jobs_no_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(metrics, "PROMETHEUS_JOBS_PATH", str(tmp_path / "jobs.json"))
+    jobs = await metrics.get_jobs()
+    assert jobs == []
+
+
+@pytest.mark.asyncio
+async def test_add_and_delete_job(tmp_path, monkeypatch):
+    path = tmp_path / "jobs.json"
+    monkeypatch.setattr(metrics, "PROMETHEUS_JOBS_PATH", str(path))
+
+    result = await metrics.add_job(Job(job="test", targets=["localhost"]))
+    assert result["status"] == "added"
+
+    result2 = await metrics.add_job(Job(job="test", targets=["localhost"]))
+    assert result2["status"] == "already exists"
+
+    delete_res = await metrics.delete_job("test")
+    assert delete_res["status"] == "deleted"
+    with open(path) as f:
+        data = json.load(f)
+    assert data == []

--- a/backend/tests/test_sender_adapter.py
+++ b/backend/tests/test_sender_adapter.py
@@ -1,0 +1,73 @@
+import types
+import pytest
+
+from backend.services import sender_adapter
+
+
+class FakeResponse:
+    def __init__(self, data=None, status_code=200, content=b"", headers=None):
+        self._data = data or {}
+        self.status_code = status_code
+        self.content = content
+        self.headers = headers or {}
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+class FakeAsyncClient:
+    def __init__(self, get_resp=None, post_resp=None):
+        self.get_resp = get_resp
+        self.post_resp = post_resp
+        self.last_post = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get(self, *args, **kwargs):
+        return self.get_resp
+
+    async def post(self, url, json=None, data=None, files=None):
+        self.last_post = {"url": url, "json": json, "data": data, "files": files}
+        return self.post_resp
+
+
+@pytest.mark.asyncio
+async def test_send_message(monkeypatch):
+    client = FakeAsyncClient(post_resp=FakeResponse({"ok": True}, 200))
+    monkeypatch.setattr(
+        sender_adapter,
+        "httpx",
+        types.SimpleNamespace(AsyncClient=lambda *a, **k: client),
+    )
+    res = await sender_adapter.send_message("token", 1, "hello")
+    assert res["status_code"] == 200
+    assert client.last_post["json"]["text"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_send_media(monkeypatch):
+    get_resp = FakeResponse(content=b"data", headers={"Content-Disposition": 'attachment; filename="f.txt"'})
+    post_resp = FakeResponse({"ok": True}, 200)
+    client = FakeAsyncClient(get_resp=get_resp, post_resp=post_resp)
+    monkeypatch.setattr(
+        sender_adapter,
+        "httpx",
+        types.SimpleNamespace(AsyncClient=lambda *a, **k: client),
+    )
+    res = await sender_adapter.send_media(
+        "token",
+        1,
+        "Image",
+        "http://example.com/f.txt",
+        "text/plain",
+        "caption",
+    )
+    assert res["status_code"] == 200
+    assert "photo" in client.last_post["files"]

--- a/backend/tests/test_telegram_router.py
+++ b/backend/tests/test_telegram_router.py
@@ -1,0 +1,21 @@
+import types
+import pytest
+from backend.routers import telegram
+
+
+class FakeRequest:
+    def __init__(self, data):
+        self._data = data
+
+    async def json(self):
+        return self._data
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_unsupported(monkeypatch):
+    monkeypatch.setattr(telegram.db, "get_bot_token", lambda bot_id: "token")
+    monkeypatch.setattr(telegram.db, "get_bot_locale", lambda bot_id: "en")
+    request = FakeRequest({"unknown": {}})
+    resp = await telegram.handle_webhook(1, request)
+    assert resp.status_code == 200
+    assert resp.body

--- a/backend/tests/test_webhook_server.py
+++ b/backend/tests/test_webhook_server.py
@@ -1,0 +1,86 @@
+import types
+import pytest
+
+from backend.services import webhook_server
+
+
+class FakeResponse:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+        self.headers = {}
+        self.content = b""
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        pass
+
+
+class FakeAsyncClient:
+    def __init__(self, get_resp=None, post_resp=None):
+        self.get_resp = get_resp
+        self.post_resp = post_resp
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def get(self, *args, **kwargs):
+        return self.get_resp
+
+    async def post(self, *args, **kwargs):
+        return self.post_resp
+
+
+@pytest.mark.asyncio
+async def test_get_bot_id(monkeypatch):
+    resp = FakeResponse({"ok": True, "result": {"id": 42}})
+    monkeypatch.setattr(
+        webhook_server,
+        "httpx",
+        types.SimpleNamespace(AsyncClient=lambda *a, **k: FakeAsyncClient(get_resp=resp)),
+    )
+    bot_id = await webhook_server.get_bot_id("token")
+    assert bot_id == 42
+
+
+@pytest.mark.asyncio
+async def test_get_bot_name(monkeypatch):
+    resp = FakeResponse({"ok": True, "result": {"username": "bot"}})
+    monkeypatch.setattr(
+        webhook_server,
+        "httpx",
+        types.SimpleNamespace(AsyncClient=lambda *a, **k: FakeAsyncClient(get_resp=resp)),
+    )
+    name = await webhook_server.get_bot_name("token")
+    assert name == "bot"
+
+
+@pytest.mark.asyncio
+async def test_set_webhook(monkeypatch):
+    resp = FakeResponse({"ok": True}, status_code=200)
+    monkeypatch.setattr(
+        webhook_server,
+        "httpx",
+        types.SimpleNamespace(AsyncClient=lambda *a, **k: FakeAsyncClient(post_resp=resp)),
+    )
+    result = await webhook_server.set_webhook("token", "http://url")
+    assert result["status_code"] == 200
+    assert result["body"]["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_delete_webhook(monkeypatch):
+    resp = FakeResponse({"ok": True}, status_code=200)
+    monkeypatch.setattr(
+        webhook_server,
+        "httpx",
+        types.SimpleNamespace(AsyncClient=lambda *a, **k: FakeAsyncClient(post_resp=resp)),
+    )
+    result = await webhook_server.delete_webhook("token")
+    assert result["status_code"] == 200
+    assert result["body"]["ok"] is True

--- a/config
+++ b/config
@@ -1,0 +1,1 @@
+backend/config

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = backend/tests
+addopts = -vv
+asyncio_mode = auto


### PR DESCRIPTION
## Summary
- add pytest configuration and root symlink for config
- implement fixtures to fake DB and environment
- provide tests covering helper functions, routers and services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d164b8cac832b9c0f7b39905f7381