### PR TITLE
Implement bot-specific project selection

### DIFF
--- a/backend/constants/postgres_models.py
+++ b/backend/constants/postgres_models.py
@@ -163,13 +163,20 @@ class UserProjectSelection(Base):
 
     user_id = Column(BigInteger, ForeignKey('users.id', ondelete='CASCADE'), primary_key=True)
     project_id = Column(BigInteger, ForeignKey('projects.id', ondelete='CASCADE'), primary_key=True)
+    bot_id = Column(BigInteger, ForeignKey('bots.id', ondelete='CASCADE'), primary_key=True)
     is_selected = Column(Boolean, default=False, nullable=False)
 
     user = relationship("User", back_populates="projects")
     project = relationship("Project", back_populates="users")
 
     __table_args__ = (
-        Index('ix_user_project_selection_user_id_project_id', 'user_id', 'project_id', unique=True),
+        Index(
+            'ix_user_project_selection',
+            'user_id',
+            'project_id',
+            'bot_id',
+            unique=True,
+        ),
     )
 
 

--- a/backend/routers/constructor.py
+++ b/backend/routers/constructor.py
@@ -210,7 +210,7 @@ async def send_system_message(request: SendSystemMessageRequest):
 
             session_id = project_data.get("session_id")
             if session_id:
-                selected_project_id = db.get_selected_project_id(chat_id)
+                selected_project_id = db.get_selected_project_id(messenger_id, chat_id)
                 if selected_project_id:
                     rdb.Session.set(messenger_id, chat_id, session_id, selected_project_id)
         
@@ -220,7 +220,7 @@ async def send_system_message(request: SendSystemMessageRequest):
             if session_id:
                 project_id = rdb.Session.get(messenger_id, chat_id, session_id)
 
-                db.deselect_project(project_id, chat_id)
+                db.deselect_project(project_id, messenger_id, chat_id)
 
                 rdb.Session.delete(messenger_id, chat_id, session_id)
         

--- a/backend/routers/telegram.py
+++ b/backend/routers/telegram.py
@@ -96,10 +96,10 @@ async def _handle_contact(bot_id: int, token: str, contact_id: int, contact_info
         bot_id=bot_id,
     )
 
-    project_restart_code = db.get_selected_project_code(contact_id)
+    project_restart_code = db.get_selected_project_code(bot_id, contact_id)
     if project_restart_code is None:
         db.set_main_as_selected(bot_id, contact_id)
-        project_restart_code = db.get_selected_project_code(contact_id)
+        project_restart_code = db.get_selected_project_code(bot_id, contact_id)
 
     restart_request_body = sa._build_event_request(message_id, project_restart_code, contact_id, bot_id, participant_name)
 
@@ -272,7 +272,7 @@ async def handle_webhook(bot_id: int, request: Request):
 
         if db.no_project_selected(bot_id, contact_id):
             db.set_main_as_selected(bot_id, contact_id)
-            project_restart_code = db.get_selected_project_code(contact_id)
+            project_restart_code = db.get_selected_project_code(bot_id, contact_id)
             project_restart_code += f"_{message_id}"
             restart_request_body = sa._build_event_request(
                 message_id,
@@ -314,7 +314,7 @@ async def handle_webhook(bot_id: int, request: Request):
             project_match = db.find_project_by_command(bot_id, contact_id, command_text)
             if project_match:
                 project_id, project_code = project_match
-                db.set_project_selected(project_id, contact_id)
+                db.set_project_selected(bot_id, project_id, contact_id)
                 restart_request_body = sa._build_event_request(
                     message_id,
                     project_code,


### PR DESCRIPTION
## Summary
- store selected project per bot by adding `bot_id` to `UserProjectSelection`
- handle selection per bot in DB helpers
- update Telegram and constructor routers to use new APIs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e96e154c832b8ed76ea3c8eee131