### PR TITLE
Fix numeric message ids

### DIFF
--- a/backend/routers/constructor.py
+++ b/backend/routers/constructor.py
@@ -6,7 +6,7 @@ import services.sender_adapter as sa
 import services.db as db
 from services.logging_setup import interaction_logger
 import constants.redis_models as rdb
-import services.sender_adapter as sa
+import services.helper_functions as hf
 import json
 
 router = APIRouter(tags=["Constructor"])
@@ -197,7 +197,7 @@ async def send_system_message(request: SendSystemMessageRequest):
                 if cached:
                     text, participant, attachments, message_type = cached
                     request_body = sa._build_event_request(
-                        str(int(message_id) * 10),
+                        hf.generate_message_id(),
                         text,
                         chat_id,
                         messenger_id,

--- a/backend/services/helper_functions.py
+++ b/backend/services/helper_functions.py
@@ -17,6 +17,11 @@ def generate_uuid():
     return str(uuid.uuid4())
 
 
+def generate_message_id() -> str:
+    """Return a numeric string suitable for message IDs."""
+    return str(uuid.uuid4().int >> 64)
+
+
 translit_map = {
     'а': 'a', 'б': 'b', 'в': 'v', 'г': 'g', 'д': 'd',
     'е': 'e', 'ё': 'e', 'ж': 'zh','з': 'z', 'и': 'i',

--- a/backend/services/sender_adapter.py
+++ b/backend/services/sender_adapter.py
@@ -149,7 +149,7 @@ async def send_media(
 
 
 def _build_event_request(
-    message_id: int,
+    message_id: str,
     text: str,
     contact_id: int,
     messengerId: int,

--- a/backend/tests/test_helper_functions.py
+++ b/backend/tests/test_helper_functions.py
@@ -2,6 +2,7 @@ import re
 from backend.services.helper_functions import (
     guess_filename,
     generate_uuid,
+    generate_message_id,
     extract_telegram_attachments,
 )
 
@@ -22,6 +23,14 @@ def test_generate_uuid_unique():
     assert uuid1 != uuid2
     assert pattern.match(uuid1)
     assert pattern.match(uuid2)
+
+
+def test_generate_message_id_numeric_and_unique():
+    mid1 = generate_message_id()
+    mid2 = generate_message_id()
+    assert mid1 != mid2
+    assert mid1.isdigit()
+    assert mid2.isdigit()
 
 
 def test_extract_telegram_attachments_photo():


### PR DESCRIPTION
## Summary
- generate a numeric message ID string with a helper function
- use the new helper when forwarding cached messages
- update event request typing to accept string IDs
- add tests for message ID generation

## Testing
- `pip install -q -r backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863174f4b14832b845ba8e53ef65051